### PR TITLE
Add accessibility add-on

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,0 +1,2 @@
+import '@kadira/storybook/addons';
+import 'storybook-addon-a11y/register';

--- a/ColabTool/ImagePost/story.jsx
+++ b/ColabTool/ImagePost/story.jsx
@@ -3,6 +3,7 @@ import {
   storiesOf,
   action,
 } from '@kadira/storybook';
+import { checkA11y } from 'storybook-addon-a11y';
 import ImagePost from './index';
 
 const links = [{
@@ -36,6 +37,7 @@ const tallImage = 'http://lorempixel.com/400/900/cats/';
 const wideImage = 'http://lorempixel.com/900/400/cats/';
 
 storiesOf('ImagePost')
+  .addDecorator(checkA11y)
   .add('default', () => (
     <ImagePost
       imageSrc={imageSrc}

--- a/ColabTool/LinkPost/story.jsx
+++ b/ColabTool/LinkPost/story.jsx
@@ -3,6 +3,7 @@ import {
   storiesOf,
   action,
 } from '@kadira/storybook';
+import { checkA11y } from 'storybook-addon-a11y';
 import LinkPost from './index';
 
 const links = [{
@@ -35,6 +36,7 @@ const tallImage = 'http://lorempixel.com/400/900/cats/';
 const wideImage = 'http://lorempixel.com/900/400/cats/';
 
 storiesOf('LinkPost')
+  .addDecorator(checkA11y)
   .add('default', () => (
     <LinkPost
       links={links}

--- a/ColabTool/Shared/Post/story.jsx
+++ b/ColabTool/Shared/Post/story.jsx
@@ -4,6 +4,7 @@ import {
   action,
 } from '@kadira/storybook';
 import { linkTo } from '@kadira/storybook-addon-links';
+import { checkA11y } from 'storybook-addon-a11y';
 import { Text } from '@bufferapp/components';
 import Post from './index';
 
@@ -29,6 +30,7 @@ const children = (
 );
 
 storiesOf('Post')
+  .addDecorator(checkA11y)
   .add('default', () => (
     <Post
       draftDetails={draftDetails}

--- a/ColabTool/Shared/PostButtonPanel/story.jsx
+++ b/ColabTool/Shared/PostButtonPanel/story.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { storiesOf, action } from '@kadira/storybook';
 import { linkTo } from '@kadira/storybook-addon-links';
+import { checkA11y } from 'storybook-addon-a11y';
 import PostButtonPanel from './index';
 
 storiesOf('PostButtonPanel')
+  .addDecorator(checkA11y)
   .add('member', () => (
     <PostButtonPanel
       onApproveClick={linkTo('PostButtonPanel', 'member, isWorking')}

--- a/ColabTool/Shared/PostDetails/story.jsx
+++ b/ColabTool/Shared/PostDetails/story.jsx
@@ -4,6 +4,7 @@ import {
   action,
 } from '@kadira/storybook';
 import { linkTo } from '@kadira/storybook-addon-links';
+import { checkA11y } from 'storybook-addon-a11y';
 import PostDetails from './index';
 
 const draftDetails = {
@@ -16,6 +17,7 @@ const draftDetails = {
 };
 
 storiesOf('PostDetails')
+  .addDecorator(checkA11y)
   .add('default', () => (
     <PostDetails
       onCancelConfirmClick={linkTo('PostDetails', 'default')}

--- a/ColabTool/Shared/PostTopDetails/story.jsx
+++ b/ColabTool/Shared/PostTopDetails/story.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   storiesOf,
 } from '@kadira/storybook';
+import { checkA11y } from 'storybook-addon-a11y';
 import PostTopDetails from './index';
 
 const draftDetails = {
@@ -59,6 +60,7 @@ const noNameOrEmailJustTimeDraftDetails = {
 };
 
 storiesOf('PostTopDetails')
+  .addDecorator(checkA11y)
   .add('default', () => (
     <PostTopDetails
       draftDetails={draftDetails}

--- a/ColabTool/Shared/RetweetPanel/story.jsx
+++ b/ColabTool/Shared/RetweetPanel/story.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { storiesOf } from '@kadira/storybook';
+import { checkA11y } from 'storybook-addon-a11y';
 import RetweetPanel from './index';
 
 storiesOf('RetweetPanel')
+  .addDecorator(checkA11y)
   .add('default', () => (
     <RetweetPanel
       name={'Joel Gascoigne'}

--- a/ColabTool/TextPost/story.jsx
+++ b/ColabTool/TextPost/story.jsx
@@ -3,6 +3,7 @@ import {
   storiesOf,
   action,
 } from '@kadira/storybook';
+import { checkA11y } from 'storybook-addon-a11y';
 import TextPost from './index';
 
 const links = [{
@@ -31,6 +32,7 @@ const retweetProfile = {
 
 
 storiesOf('TextPost')
+  .addDecorator(checkA11y)
   .add('default', () => (
     <TextPost
       links={links}

--- a/ScheduleTag/story.jsx
+++ b/ScheduleTag/story.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { storiesOf } from '@kadira/storybook';
+import { checkA11y } from 'storybook-addon-a11y';
 import ScheduleTag from './index';
 
 const date = '08:52am (GMC)';
 
 storiesOf('ScheduleTag')
+  .addDecorator(checkA11y)
   .add('Default', () => (
     <ScheduleTag dateString={date} />
   ));

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "react-addons-test-utils": "15.4.2",
     "react-dom": "15.4.2",
     "react-test-renderer": "15.4.2",
+    "storybook-addon-a11y": "0.0.4",
     "storyshots": "3.2.2",
     "style-loader": "0.13.2"
   },


### PR DESCRIPTION
### Purpose
This PR introduce accessibility checks to all of our components using [storybook-addon-a11y](https://github.com/jbovenschen/storybook-addon-a11y).
### Things to Note
Added an `addons.js` file to our `.storybook` directory.
### Review
Nothing in particular for this one -- it's the same process as [what we did](https://github.com/bufferapp/buffer-components/pull/41) for `buffer-components`.