### PR TITLE
Add percy-storybook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ node_modules
 .npm
 /coverage
 /.vscode
+
+# The static storybook build created by build-storybook
+storybook-static

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "start-storybook -p 9002",
     "deploy-storybook": "storybook-to-ghpages",
     "lint": "./node_modules/eslint/bin/eslint.js . --ignore-pattern coverage .storybook node_modules",
+    "percy-snapshot": "build-storybook && percy-storybook --ignore=\"node_modules(?!\/@bufferapp\/components)\"",
     "test": "npm run lint && jest --coverage",
     "test-watch": "jest --watch",
     "test-update": "jest -u"
@@ -49,6 +50,7 @@
     "@kadira/storybook": "2.35.3",
     "@kadira/storybook-addon-links": "1.0.1",
     "@kadira/storybook-deployer": "1.2.0",
+    "@percy-io/react-percy-storybook": "0.1.2",
     "babel-cli": "6.24.0",
     "babel-eslint": "7.2.1",
     "babel-jest": "19.0.0",


### PR DESCRIPTION
Discussed with @hharnisc. Making a PR here to make it easy for Harrison to explore. 

### Purpose
Add percy-storybook.  Will take visual snapshots of the web components, and show changes in Percy.io

### Things to Note
This adds one package and one script to the package.json.

To run it in development mode, setup the environment variables* and run `npm run percy-snapshot`.

After you're happy that it's running nicely, and creating nice deterministic screenshots, add it to your CI builds to add automatic visual regression testing and reviews.  This could be done on the buffer-components repo too if useful.

The two environment variables you'll need to set before running it are `PERCY_TOKEN` and `PERCY_PROJECT`.  They are available via https://percy.io from project settings.

